### PR TITLE
Fix/avatar dropdown logout

### DIFF
--- a/docs/releases/CHANGELOG.md
+++ b/docs/releases/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- ...
+- `AvatarDropdown.tsx` now displays the real user's name initial and username from `localStorage`.
 
 ### Deprecated
 
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- ...
+- Logout button in `AvatarDropdown.tsx` now calls `POST /api/logout` to invalidate the Sanctum token on the server before clearing `localStorage` and redirecting to `/`. Local logout still proceeds if the request fails.
 
 ### Security
 

--- a/frontend/src/app/components/AvatarDropdown.tsx
+++ b/frontend/src/app/components/AvatarDropdown.tsx
@@ -7,16 +7,36 @@ export default function AvatarDropdown() {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
 
+  const authUser = JSON.parse(localStorage.getItem("user") || "{}");
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);
       }
     };
-
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
+
+  const handleLogout = async () => {
+    try {
+      const token = localStorage.getItem("token");
+      await fetch("http://api.devhub.com/api/logout", {
+        method: "POST",
+        headers: {
+          "Accept": "application/json",
+          "Authorization": `Bearer ${token}`,
+        },
+      });
+    } catch {
+      // si falla el request, el logout local sigue adelante
+    } finally {
+      localStorage.removeItem("token");
+      localStorage.removeItem("user");
+      navigate("/");
+    }
+  };
 
   const menuItems = [
     { label: "Mi Perfil", icon: User, action: () => navigate("/profile") },
@@ -24,7 +44,7 @@ export default function AvatarDropdown() {
     { label: "Personalización", icon: Palette, action: () => navigate("/customization") },
     { label: "Términos de Uso", icon: FileText, action: () => navigate("/terms") },
     { label: "Ayuda", icon: HelpCircle, action: () => navigate("/help") },
-    { label: "Cerrar Sesión", icon: LogOut, action: () => navigate("/"), divider: true, isLogout: true },
+    { label: "Cerrar Sesión", icon: LogOut, action: handleLogout, divider: true, isLogout: true },
   ];
 
   return (
@@ -37,11 +57,11 @@ export default function AvatarDropdown() {
           className="w-10 h-10 rounded-full flex items-center justify-center text-white font-semibold"
           style={{ backgroundColor: "#7C3AED" }}
         >
-          P
+          {authUser.name?.[0]?.toUpperCase() ?? "?"}
         </div>
         <div className="text-left">
-          <p className="font-semibold" style={{ color: "#1A1A2E" }}>@desarrollador</p>
-          <p className="text-xs" style={{ color: "#6B6880" }}>Junior Dev</p>
+          <p className="font-semibold" style={{ color: "#1A1A2E" }}>@{authUser.username ?? "usuario"}</p>
+          <p className="text-xs" style={{ color: "#6B6880" }}>Developer</p>
         </div>
         <ChevronDown
           size={16}
@@ -49,10 +69,9 @@ export default function AvatarDropdown() {
           className={`transition-transform ${isOpen ? "rotate-180" : ""}`}
         />
       </button>
-
       {isOpen && (
         <div className="absolute right-0 mt-2 w-56 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
-          {menuItems.map((item, index) => (
+          {menuItems.map((item) => (
             <div key={item.label}>
               {item.divider && <div className="border-t border-gray-200 my-2" />}
               <button


### PR DESCRIPTION
## Summary

Fix logout to invalidate Sanctum token on the server and display real user data in AvatarDropdown.

## Details

### Changed

- `AvatarDropdown.tsx` now displays the real user's name initial and username from `localStorage`.

### Fixed

- Logout button in `AvatarDropdown.tsx` now calls `POST /api/logout` to invalidate the Sanctum token on the server before clearing `localStorage` and redirecting to `/`. Local logout still proceeds if the request fails.

## References

[Example](github.com)

## Checks

- [x] Tested changes
- [x] Stakeholder approval

## Issues

Closes #15 
