### PR TITLE
Fix/add project modal tags

### DIFF
--- a/docs/date/20260507.md
+++ b/docs/date/20260507.md
@@ -1,0 +1,11 @@
+# 2026/05/07
+
+# Etiquetas tech stack al crear un proyecto
+
+```shell
+curl -X POST http://api.devhub.com/api/projects \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer 1|hJAWha4FEVlL6zF5LYcUKjwvS33DP7lLKv5RkgFU67ae7755" \
+  -d '{"title":"Test tags","description":"Prueba","tags":["React","Laravel"],"project_link":"https://test.com"}'
+```

--- a/docs/releases/CHANGELOG.md
+++ b/docs/releases/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- ...
+- Tech stack tags in `AddProjectModal.tsx` are now captured on form submit even if the user did not press Enter, by splitting the remaining input by commas.
 
 ### Security
 

--- a/frontend/src/app/components/AddProjectModal.tsx
+++ b/frontend/src/app/components/AddProjectModal.tsx
@@ -39,10 +39,13 @@ export default function AddProjectModal({ isOpen, onClose, onSubmit }: AddProjec
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const finalTags = tagInput.trim()
+      ? [...tags, ...tagInput.split(",").map((t) => t.trim()).filter(Boolean)]
+      : tags;
     onSubmit({
       title,
       description,
-      tags,
+      tags: finalTags,
       projectLink,
       githubLink,
     });


### PR DESCRIPTION
## Summary

Fix tech stack tags not being saved when submitting the project form without pressing Enter.

## Details

### Fixed

- Tech stack tags in `AddProjectModal.tsx` are now captured on form submit even if the user did not press Enter, by splitting the remaining input by commas.

## References

[Example](github.com)

## Checks

- [x] Tested changes
- [x] Stakeholder approval

## Issues

Closes #19 
