### PR TITLE
Feature/delete project button

### DIFF
--- a/docs/releases/CHANGELOG.md
+++ b/docs/releases/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- ...
+- Delete button on project cards in `Feed.tsx`, visible only to the project owner, that calls `DELETE /api/projects/{id}` and removes the card from the UI without reloading.
+- Delete button on project cards in `Profile.tsx` that calls `DELETE /api/projects/{id}` and removes the card from the list without reloading.
 
 ### Changed
 

--- a/frontend/src/app/pages/Feed.tsx
+++ b/frontend/src/app/pages/Feed.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router";
-import { Eye, MessageCircle, ExternalLink, Search, Plus } from "lucide-react";
+import { Eye, MessageCircle, ExternalLink, Search, Plus, Trash2 } from "lucide-react";
 import Sidebar from "../components/Sidebar";
 import AvatarDropdown from "../components/AvatarDropdown";
 import StarRating from "../components/StarRating";
@@ -53,6 +53,7 @@ export default function Feed() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const authUser = JSON.parse(localStorage.getItem("user") || "{}");
 
   useEffect(() => {
     const fetchProjects = async () => {
@@ -106,6 +107,24 @@ export default function Feed() {
       setIsAddProjectModalOpen(false);
     } catch (err) {
       console.error(err);
+    }
+  };
+
+  const handleDeleteProject = async (projectId: number) => {
+    if (!confirm("¿Seguro que quieres eliminar este proyecto?")) return;
+    try {
+      const token = localStorage.getItem("token");
+      const res = await fetch(`http://api.devhub.com/api/projects/${projectId}`, {
+        method: "DELETE",
+        headers: {
+          "Accept": "application/json",
+          "Authorization": `Bearer ${token}`,
+        },
+      });
+      if (!res.ok) throw new Error();
+      setProjects((prev) => prev.filter((p) => p.id !== projectId));
+    } catch {
+      console.error("Error al eliminar el proyecto");
     }
   };
 
@@ -185,12 +204,28 @@ export default function Feed() {
                     borderLeft: `3px solid ${tagColor}`,
                   }}
                 >
-                  <div className="flex items-center gap-2 mb-2">
-                    <div className="w-8 h-8 rounded-full flex items-center justify-center text-white text-xs font-bold border-2"
-                      style={{ background: gradient, borderColor: "rgba(124,58,237,0.4)" }}>
-                      {project.user.name[0].toUpperCase()}
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center gap-2">
+                      <div className="w-8 h-8 rounded-full flex items-center justify-center text-white text-xs font-bold border-2"
+                        style={{ background: gradient, borderColor: "rgba(124,58,237,0.4)" }}>
+                        {project.user.name[0].toUpperCase()}
+                      </div>
+                      <p className="text-xs" style={{ color: "#6B6880" }}>@{project.user.username}</p>
                     </div>
-                    <p className="text-xs" style={{ color: "#6B6880" }}>@{project.user.username}</p>
+
+                    {authUser.id === project.user_id && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDeleteProject(project.id);
+                        }}
+                        className="p-1.5 rounded-lg transition-all hover:bg-red-50"
+                        style={{ color: "#DC2626" }}
+                        title="Eliminar proyecto"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    )}
                   </div>
 
                   <button onClick={() => navigate(`/project/${project.id}`)} className="text-left w-full group">

--- a/frontend/src/app/pages/Profile.tsx
+++ b/frontend/src/app/pages/Profile.tsx
@@ -4,7 +4,7 @@ import Sidebar from "../components/Sidebar";
 import AvatarDropdown from "../components/AvatarDropdown";
 import StarRating from "../components/StarRating";
 import AddProjectModal from "../components/AddProjectModal";
-import { Users, Eye, MessageCircle, ExternalLink, Send, Search, Plus } from "lucide-react";
+import { Users, Eye, MessageCircle, ExternalLink, Send, Plus, Trash2 } from "lucide-react";
 import { getTechTagColors } from "../utils/techTagColors";
 
 interface Project {
@@ -148,6 +148,24 @@ export default function Profile() {
     }
   };
 
+  const handleDeleteProject = async (projectId: number) => {
+    if (!confirm("¿Seguro que quieres eliminar este proyecto?")) return;
+    try {
+      const token = localStorage.getItem("token");
+      const res = await fetch(`http://api.devhub.com/api/projects/${projectId}`, {
+        method: "DELETE",
+        headers: {
+          "Accept": "application/json",
+          "Authorization": `Bearer ${token}`,
+        },
+      });
+      if (!res.ok) throw new Error();
+      setProjects((prev) => prev.filter((p) => p.id !== projectId));
+    } catch {
+      console.error("Error al eliminar el proyecto");
+    }
+  };
+
   const filteredProjects = projects.filter((project) =>
     project.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
     project.description.toLowerCase().includes(searchQuery.toLowerCase())
@@ -270,11 +288,26 @@ export default function Profile() {
                     borderColor: hoveredProject === project.id ? "#7C3AED" : "#EDE9FA",
                     boxShadow: hoveredProject === project.id ? "0 4px 16px rgba(124,58,237,0.12)" : "none"
                   }}>
-                  <button onClick={() => navigate(`/project/${project.id}`)}
-                    className="absolute top-6 right-6 transition-opacity"
-                    style={{ color: "#7C3AED", opacity: hoveredProject === project.id ? 1 : 0 }}>
-                    <ExternalLink size={18} />
-                  </button>
+
+                  {/* Botones top-right: eliminar y abrir */}
+                  <div className="absolute top-6 right-6 flex items-center gap-2">
+                    <button
+                      onClick={() => handleDeleteProject(project.id)}
+                      className="p-1.5 rounded-lg transition-all hover:bg-red-50"
+                      style={{ color: "#DC2626" }}
+                      title="Eliminar proyecto"
+                    >
+                      <Trash2 size={16} />
+                    </button>
+                    <button
+                      onClick={() => navigate(`/project/${project.id}`)}
+                      className="transition-opacity"
+                      style={{ color: "#7C3AED", opacity: hoveredProject === project.id ? 1 : 0 }}
+                    >
+                      <ExternalLink size={18} />
+                    </button>
+                  </div>
+
                   <button onClick={() => navigate(`/project/${project.id}`)} className="text-left w-full">
                     <h4 className="text-xl font-bold mb-3 hover:underline" style={{ color: "#7C3AED" }}>
                       {project.title}


### PR DESCRIPTION
## Summary

Add delete button on project cards for the project owner in Feed and Profile pages.

## Details

### Added

- Delete button on project cards in `Feed.tsx`, visible only to the project owner, that calls `DELETE /api/projects/{id}` and removes the card from the UI without reloading.
- Delete button on project cards in `Profile.tsx` that calls `DELETE /api/projects/{id}` and removes the card from the list without reloading.

## References

[Example](github.com)

## Checks

- [x] Tested changes
- [x] Stakeholder approval

## Issues

Closes #21 
