### PR TITLE
Feature/project views

### DIFF
--- a/backend/app/Http/Controllers/Api/ProjectController.php
+++ b/backend/app/Http/Controllers/Api/ProjectController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Project;
+use App\Models\ProjectView;
 use Illuminate\Http\Request;
 
 class ProjectController extends Controller
@@ -14,7 +15,7 @@ class ProjectController extends Controller
     public function index()
     {
         $projects = Project::with('user')
-            ->withCount('comments')
+            ->withCount(['views', 'comments'])
             ->latest()
             ->paginate(10);
 
@@ -39,9 +40,16 @@ class ProjectController extends Controller
         return response()->json($project->load('user'), 201);
     }
 
-    public function show(Project $project)
+    public function show(Request $request, Project $project)
     {
-        return response()->json($project->load('user')->loadCount('comments'));
+        ProjectView::firstOrCreate([
+            'user_id'    => $request->user()->id,
+            'project_id' => $project->id,
+        ]);
+
+        return response()->json(
+            $project->load('user')->loadCount(['views', 'comments'])
+        );
     }
 
     public function update(Request $request, Project $project)
@@ -79,7 +87,7 @@ class ProjectController extends Controller
     {
         $projects = $request->user()
             ->projects()
-            ->withCount('comments')
+            ->withCount(['views', 'comments'])
             ->latest()
             ->paginate(10);
 

--- a/backend/app/Http/Controllers/Api/UserController.php
+++ b/backend/app/Http/Controllers/Api/UserController.php
@@ -72,7 +72,7 @@ class UserController extends Controller
     public function showProjects(User $user)
     {
         $projects = $user->projects()
-            ->withCount('comments')
+            ->withCount(['views', 'comments'])
             ->latest()
             ->paginate(10);
 

--- a/backend/app/Models/Project.php
+++ b/backend/app/Models/Project.php
@@ -26,6 +26,11 @@ class Project extends Model
         return $this->belongsTo(User::class);
     }
 
+    public function views()
+    {
+        return $this->hasMany(ProjectView::class);
+    }
+
     public function comments()
     {
         return $this->hasMany(Comment::class);

--- a/backend/app/Models/ProjectView.php
+++ b/backend/app/Models/ProjectView.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ProjectView extends Model
+{
+    public $timestamps = false;
+    protected $fillable = ['user_id', 'project_id'];
+
+    protected static function booted()
+    {
+        static::creating(function ($view) {
+            $view->created_at = now();
+        });
+    }
+}

--- a/backend/database/migrations/2026_05_07_194106_create_project_views_table.php
+++ b/backend/database/migrations/2026_05_07_194106_create_project_views_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('project_views', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->unique(['user_id', 'project_id']);
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('project_views');
+    }
+};

--- a/docs/date/20260507.md
+++ b/docs/date/20260507.md
@@ -27,3 +27,11 @@ curl http://api.devhub.com/api/projects \
   -H "Accept: application/json" \
   -H "Authorization: Bearer 1|hJAWha4FEVlL6zF5LYcUKjwvS33DP7lLKv5RkgFU67ae7755"
 ```
+
+# Contador de visitas en proyectos
+
+```shell
+curl http://api.devhub.com/api/projects/1 \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer 1|hJAWha4FEVlL6zF5LYcUKjwvS33DP7lLKv5RkgFU67ae7755"
+```

--- a/docs/releases/CHANGELOG.md
+++ b/docs/releases/CHANGELOG.md
@@ -22,11 +22,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Relative timestamps on comments using a `timeAgo` helper function.
 - `comments_count` field added to all project endpoints (`index`, `show`, `myProjects`, `showProjects`).
 - Comment count now displays in real time on project cards in `Feed.tsx`, `Profile.tsx` and `UserProfile.tsx`.
+- `project_views` table migration with `user_id`, `project_id` and unique constraint to prevent duplicate views.
+- `ProjectView` Eloquent model.
+- `views` relationship added to `Project` model.
+- `GET /api/projects/{id}` now registers a unique view per authenticated user using `firstOrCreate`.
+- `views_count` field added to all project endpoints (`index`, `show`, `myProjects`, `showProjects`).
+- View count now displays in real time on project cards in `Feed.tsx`, `Profile.tsx` and `UserProfile.tsx`.
 
 ### Changed
 
 - `ProjectDetail.tsx` migrated from static mock comments to real API data.
 - `Feed.tsx`, `Profile.tsx` and `UserProfile.tsx` updated to show real comment counts.
+- `ProjectController@show` updated to accept `Request` and register a unique project view on each visit.
+- `Feed.tsx`, `Profile.tsx` and `UserProfile.tsx` updated to show real view counts.
 
 ### Deprecated
 

--- a/frontend/src/app/pages/Feed.tsx
+++ b/frontend/src/app/pages/Feed.tsx
@@ -22,6 +22,7 @@ interface Project {
     username: string;
     avatar: string | null;
   };
+  views_count: number;
   comments_count: number;
 }
 
@@ -256,7 +257,7 @@ export default function Feed() {
                     <div className="flex items-center gap-4" style={{ color: "#6B6880" }}>
                       <div className="flex items-center gap-1.5">
                         <Eye size={16} />
-                        <span className="text-xs">0</span>
+                        <span className="text-xs">{project.views_count}</span>
                       </div>
                       <div className="flex items-center gap-1.5">
                         <MessageCircle size={16} />

--- a/frontend/src/app/pages/Profile.tsx
+++ b/frontend/src/app/pages/Profile.tsx
@@ -14,6 +14,7 @@ interface Project {
   tags: string[];
   project_link: string;
   github_link: string | null;
+  views_count: number;
   comments_count: number;
 }
 
@@ -264,7 +265,7 @@ export default function Profile() {
                     <div className="flex items-center gap-6" style={{ color: "#6B6880" }}>
                       <div className="flex items-center gap-2">
                         <Eye size={18} />
-                        <span className="text-sm">0</span>
+                        <span className="text-sm">{project.views_count}</span>
                       </div>
                       <div className="flex items-center gap-2">
                         <MessageCircle size={18} />

--- a/frontend/src/app/pages/UserProfile.tsx
+++ b/frontend/src/app/pages/UserProfile.tsx
@@ -25,6 +25,7 @@ interface Project {
   tags: string[];
   project_link: string;
   github_link: string | null;
+  views_count: number;
   comments_count: number;
 }
 
@@ -236,7 +237,7 @@ export default function UserProfile() {
                   </div>
                   <div className="flex items-center justify-between pt-4 border-t" style={{ borderColor: "#EDE9FA" }}>
                     <div className="flex items-center gap-6" style={{ color: "#6B6880" }}>
-                      <div className="flex items-center gap-2"><Eye size={18} /><span className="text-sm">0</span></div>
+                      <div className="flex items-center gap-2"><Eye size={18} /><span className="text-sm">{project.views_count}</span></div>
                       <div className="flex items-center gap-2"><MessageCircle size={18} /><span className="text-sm">{project.comments_count}</span></div>
                     </div>
                     <StarRating initialRating={0} />


### PR DESCRIPTION
## Summary

Track unique project views per user using a project_views table and display live view count on project cards across Feed, Profile and UserProfile.

## Details

### Added

- `project_views` table migration with `user_id`, `project_id` and unique constraint to prevent duplicate views.
- `ProjectView` Eloquent model.
- `views` relationship added to `Project` model.
- `GET /api/projects/{id}` now registers a unique view per authenticated user using `firstOrCreate`.
- `views_count` field added to all project endpoints (`index`, `show`, `myProjects`, `showProjects`).
- View count now displays in real time on project cards in `Feed.tsx`, `Profile.tsx` and `UserProfile.tsx`.

### Changed

- `ProjectController@show` updated to accept `Request` and register a unique project view on each visit.
- `Feed.tsx`, `Profile.tsx` and `UserProfile.tsx` updated to show real view counts.

## References

[Example](github.com)

## Checks

- [ ] Tested changes
- [ ] Stakeholder approval

## Issues

Closes #27 
