### PR TITLE
Feature/top technologies sidebar

### DIFF
--- a/backend/app/Http/Controllers/Api/ProjectController.php
+++ b/backend/app/Http/Controllers/Api/ProjectController.php
@@ -93,4 +93,36 @@ class ProjectController extends Controller
 
         return response()->json($projects);
     }
+
+    public function topTechnologies()
+    {
+        $projects = Project::whereNotNull('tags')->get(['tags']);
+
+        $tagCounts = [];
+        foreach ($projects as $project) {
+            foreach ($project->tags as $tag) {
+                $tag = trim($tag);
+                if ($tag) {
+                    $tagCounts[$tag] = ($tagCounts[$tag] ?? 0) + 1;
+                }
+            }
+        }
+
+        $total = array_sum($tagCounts);
+
+        if ($total === 0) {
+            return response()->json([]);
+        }
+
+        arsort($tagCounts);
+        $top5 = array_slice($tagCounts, 0, 5, true);
+
+        $result = array_map(fn($tag, $count) => [
+            'name'       => $tag,
+            'count'      => $count,
+            'percentage' => round(($count / $total) * 100, 1),
+        ], array_keys($top5), array_values($top5));
+
+        return response()->json(array_values($result));
+    }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -14,6 +14,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);
     Route::get('/posts',   [PostController::class, 'index']);
     Route::post('/posts',  [PostController::class, 'store']);
+    Route::get('/projects/top-technologies', [ProjectController::class, 'topTechnologies']);
     Route::apiResource('/projects', ProjectController::class);
     Route::get('/me/projects', [ProjectController::class, 'myProjects']);
     Route::get('/users', [UserController::class, 'index']);

--- a/docs/date/20260508.md
+++ b/docs/date/20260508.md
@@ -7,3 +7,11 @@ curl http://api.devhub.com/api/users/top \
   -H "Accept: application/json" \
   -H "Authorization: Bearer 1|hJAWha4FEVlL6zF5LYcUKjwvS33DP7lLKv5RkgFU67ae7755"
 ```
+
+## Top tecnologías
+
+```shell
+curl http://api.devhub.com/api/projects/top-technologies \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer 1|hJAWha4FEVlL6zF5LYcUKjwvS33DP7lLKv5RkgFU67ae7755"
+```

--- a/docs/releases/CHANGELOG.md
+++ b/docs/releases/CHANGELOG.md
@@ -34,6 +34,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - "Developers destacados" sidebar in `Feed.tsx` now fetches and displays real users from the API ordered by followers.
 - "Ver" button on each developer card navigates to their public profile at `/user/{id}`.
 - Empty state shown when no users are available.
+- `GET /api/projects/top-technologies` endpoint returning up to 5 tags ordered by usage count descending, with `name`, `count` and `percentage` fields.
+- `topTechnologies` method in `ProjectController`.
+- `TopTechnology` interface in `Feed.tsx`.
+- "Top tecnologías" sidebar in `Feed.tsx` now fetches and displays real technology usage from the API.
+- Percentage bar reflects each technology's share of total tag usage across the platform.
+- Empty state shown when no technologies are available.
 
 ### Changed
 
@@ -43,6 +49,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `Feed.tsx`, `Profile.tsx` and `UserProfile.tsx` updated to show real view counts.
 - `Feed.tsx` sidebar migrated from static hardcoded developers to real API data.
 - Both project and top developers fetches are now parallelized with `Promise.all` on mount.
+- `Feed.tsx` sidebar migrated from static hardcoded technologies to real API data.
+- `Promise.all` in `Feed.tsx` now fetches projects, top developers and top technologies in parallel.
 
 ### Deprecated
 
@@ -54,6 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Unused `Comment` interface, `comments` state, `newComment` state, `handleAddComment` function and related imports removed from `Profile.tsx`.
 - Static mock comments removed from `ProjectDetail.tsx`.
 - Static `featuredDevelopers` array removed from `Feed.tsx`.
+- Static `topTechnologies` array removed from `Feed.tsx`.
 
 ### Fixed
 

--- a/frontend/src/app/pages/Feed.tsx
+++ b/frontend/src/app/pages/Feed.tsx
@@ -34,13 +34,11 @@ interface FeaturedDeveloper {
   avatarGradient: string;
 }
 
-const topTechnologies = [
-  { name: "React", usage: 85 },
-  { name: "TypeScript", usage: 72 },
-  { name: "Node.js", usage: 68 },
-  { name: "Python", usage: 54 },
-  { name: "Vue", usage: 48 },
-];
+interface TopTechnology {
+  name: string;
+  count: number;
+  percentage: number;
+}
 
 const avatarGradients = [
   "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
@@ -58,6 +56,7 @@ export default function Feed() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [featuredDevelopers, setFeaturedDevelopers] = useState<FeaturedDeveloper[]>([]);
+  const [topTechnologies, setTopTechnologies] = useState<TopTechnology[]>([]);
 
   const authUser = JSON.parse(localStorage.getItem("user") || "{}");
 
@@ -70,9 +69,10 @@ export default function Feed() {
           "Authorization": `Bearer ${token}`,
         };
 
-        const [resProjects, resTop] = await Promise.all([
+        const [resProjects, resTop, resTopTech] = await Promise.all([
           fetch("http://api.devhub.com/api/projects", { headers }),
           fetch("http://api.devhub.com/api/users/top", { headers }),
+          fetch("http://api.devhub.com/api/projects/top-technologies", { headers }),
         ]);
 
         if (!resProjects.ok) throw new Error("Error al cargar los proyectos");
@@ -91,6 +91,11 @@ export default function Feed() {
               avatarGradient: avatarGradients[index % avatarGradients.length],
             }))
           );
+        }
+
+        if (resTopTech.ok) {
+          const dataTopTech = await resTopTech.json();
+          setTopTechnologies(dataTopTech);
         }
       } catch (err) {
         setError("No se pudieron cargar los proyectos.");
@@ -326,23 +331,27 @@ export default function Feed() {
             </div>
 
             <div className="bg-white rounded-xl p-6 border" style={{ borderColor: "#EDE9FA", boxShadow: "0 2px 12px rgba(124,58,237,0.06)" }}>
-              <h3 className="text-lg font-bold mb-4" style={{ color: "#1A1A2E" }}>Top tecnologías esta semana</h3>
-              <div className="space-y-3">
-                {topTechnologies.map((tech) => {
-                  const techColors = getTechTagColors(tech.name);
-                  return (
-                    <div key={tech.name}>
-                      <div className="flex items-center justify-between mb-1">
-                        <span className="text-sm font-medium" style={{ color: "#1A1A2E" }}>{tech.name}</span>
-                        <span className="text-xs font-semibold" style={{ color: techColors.color }}>{tech.usage}%</span>
+              <h3 className="text-lg font-bold mb-4" style={{ color: "#1A1A2E" }}>Top tecnologías</h3>
+              {topTechnologies.length === 0 ? (
+                <p className="text-sm text-center py-4" style={{ color: "#9B8EC4" }}>No hay tecnologías todavía.</p>
+              ) : (
+                <div className="space-y-3">
+                  {topTechnologies.map((tech) => {
+                    const techColors = getTechTagColors(tech.name);
+                    return (
+                      <div key={tech.name}>
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="text-sm font-medium" style={{ color: "#1A1A2E" }}>{tech.name}</span>
+                          <span className="text-xs font-semibold" style={{ color: techColors.color }}>{tech.percentage}%</span>
+                        </div>
+                        <div className="w-full h-1.5 rounded-full overflow-hidden" style={{ backgroundColor: "#F3F4F6" }}>
+                          <div className="h-full rounded-full transition-all" style={{ width: `${tech.percentage}%`, backgroundColor: techColors.color }} />
+                        </div>
                       </div>
-                      <div className="w-full h-1.5 rounded-full overflow-hidden" style={{ backgroundColor: "#F3F4F6" }}>
-                        <div className="h-full rounded-full transition-all" style={{ width: `${tech.usage}%`, backgroundColor: techColors.color }} />
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Replace static Top Technologies sidebar with a dynamic top 5 most used tags calculated from real project data.

## Details

### Added

- `GET /api/projects/top-technologies` endpoint returning up to 5 tags ordered by usage count descending, with `name`, `count` and `percentage` fields.
- `topTechnologies` method in `ProjectController`.
- `TopTechnology` interface in `Feed.tsx`.
- "Top tecnologías" sidebar in `Feed.tsx` now fetches and displays real technology usage from the API.
- Percentage bar reflects each technology's share of total tag usage across the platform.
- Empty state shown when no technologies are available.

### Changed

- `Feed.tsx` sidebar migrated from static hardcoded technologies to real API data.
- `Promise.all` in `Feed.tsx` now fetches projects, top developers and top technologies in parallel.

### Removed

- Static `topTechnologies` array removed from `Feed.tsx`.

## References

[Example](github.com)

## Checks

- [x] Tested changes
- [x] Stakeholder approval

## Issues

Closes #31 
